### PR TITLE
Add Brave path for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ As fallback, the last part of the path is used, e.g. `theuser1` for `Internet/gi
 - Firefox
 - Chrome
 - Chromium
+- Brave
 
 ## Contributing
 

--- a/internal/jsonapi/manifest/setup_windows.go
+++ b/internal/jsonapi/manifest/setup_windows.go
@@ -17,6 +17,7 @@ var (
 		"firefox":  `Software\Mozilla\NativeMessagingHosts\` + Name,
 		"chrome":   `Software\Google\Chrome\NativeMessagingHosts\` + Name,
 		"chromium": `Software\Google\Chrome\NativeMessagingHosts\` + Name,
+		"brave":    `Software\BraveSoftware\Brave-Browser\NativeMessagingHosts\` + Name,
 	}
 )
 


### PR DESCRIPTION
Hello,

I recently switched browsers from Chrome to Brave and I happily discovered glad that the setup of `jsonapi` was already existing for Linux!

However, when I switched as well on my Windows machine, I was surprised that Brave was not out of the box supported.

I don’t know if there is a reason for not having the same Browser support between Linux / Mac / Windows but I propose to add Brave to the Windows build with that PR.

Tested on my Windows 10 machine.

Have a nice day,
Loric