### PR TITLE
Fix command to start gopass JSON API listener in gopass v1.12.0+

### DIFF
--- a/gopass_wrapper.sh
+++ b/gopass_wrapper.sh
@@ -10,6 +10,6 @@ fi
 export PATH="$PATH:/usr/local/bin" # required on MacOS/brew
 export GPG_TTY="$(tty)"
 
-gopass jsonapi listen
+./gopass-jsonapi listen
 
 exit $?


### PR DESCRIPTION
In gopass v1.12.0, the binaries for `git-credential-gopass`, `gopass-hibp`, `gopass-jsonapi` and
`gopass-summon-provider` were removed from gopass and migrated into their own git repos. When the gopass_wrapper.sh script is executed, it tries to run 'gopass jsonapi listen' which is no longer a recognized command in gopass v1.12.0+.

With the Gopass bridge Firefox extension installed, a window pops up when the user is prompted to log into a website:

>An unexpected error occurred
Is your browser correctly set up for gopass? If you are upgrading to gopass v1.10 or newer you need to re-run the gopass-jsonapi setup command.

and the Firefox Browser Console shows this error:

```
Error: failed to retrieve secret "jsonapi": entry is not in the password store
```

The `gopass` command interprets "jsonapi" to be a secret and tries to lookup an entry for it which it does not find. The correct way to start the JSON API server is in newer versions of gopass is running `gopass-jsonapi listen` from within the cloned gopass-jsonapi git repository. I have tested this change using gopass v1.12.7 and gopass-jsonapi v1.11.1 and verified the Gopass bridge extension is able to read secrets from my gopass secret store.

Issues & PRs for reference:
- https://github.com/gopasspw/gopass/pull/1712
- https://github.com/gopasspw/gopass/issues/1673