### PR TITLE
Use /opt/homebrew/bin on recent MacOS setups

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Build gopass-jsonapi
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
 
 jobs:
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ main ]
+    branches: [ master ]
   schedule:
     - cron: '19 21 * * 0'
 

--- a/internal/jsonapi/manifest/wrapper_test.go
+++ b/internal/jsonapi/manifest/wrapper_test.go
@@ -22,6 +22,8 @@ else
 	eval $(gpg-agent --daemon)
 fi
 
+export PATH="$PATH:/usr/local/bin"
+
 gopass-jsonapi listen
 
 exit $?


### PR DESCRIPTION
This new path is required to get gopass-jsonapi to work on MacOS on ARM.

RELEASE_NOTES=[BUGFIX] Fix MacOS on Apple Silicon

Signed-off-by: Dominik Schulz <dominik.schulz@gauner.org>