### PR TITLE
gopass_wrapper.sh: Typo

### DIFF
--- a/gopass_wrapper.sh
+++ b/gopass_wrapper.sh
@@ -10,6 +10,6 @@ fi
 export PATH="$PATH:/usr/local/bin" # required on MacOS/brew
 export GPG_TTY="$(tty)"
 
-gopass jsonapi listen
+gopass-jsonapi listen
 
 exit $?


### PR DESCRIPTION
A missing -, gopass does not have a jsonapi argument. Should point to gopass-jsonapi.