### PR TITLE
Add Arc browser to user manifest_path_darwin.go

### DIFF
--- a/internal/jsonapi/manifest/manifest_path_darwin.go
+++ b/internal/jsonapi/manifest/manifest_path_darwin.go
@@ -9,6 +9,7 @@ var manifestPaths = &manifestPath{
 		"vivaldi":  "~/Library/Application Support/Vivaldi/NativeMessagingHosts",
 		"iridium":  "~/Library/Application Support/Iridium/NativeMessagingHosts",
 		"slimjet":  "~/Library/Application Support/Slimjet/NativeMessagingHosts",
+		"arc": 	    "~/Library/Application Support/Arc/User Data/NativeMessagingHosts",
 	},
 	global: map[string]string{
 		"firefox":  "/Library/Application Support/Mozilla/NativeMessagingHosts",


### PR DESCRIPTION
This is just based of my installation on osx. I did not find any global manifest files, and I don't know the corresponding structure for windows, sorry.