### PR TITLE
Fix gopass-jsonapi configuration for Brave on Windows

### DIFF
--- a/internal/jsonapi/manifest/setup_windows.go
+++ b/internal/jsonapi/manifest/setup_windows.go
@@ -20,7 +20,7 @@ var (
 		"firefox":  `Software\Mozilla\NativeMessagingHosts\` + Name,
 		"chrome":   `Software\Google\Chrome\NativeMessagingHosts\` + Name,
 		"chromium": `Software\Google\Chrome\NativeMessagingHosts\` + Name,
-		"brave":    `Software\BraveSoftware\Brave-Browser\NativeMessagingHosts\` + Name,
+		"brave":    `Software\Google\Chrome\NativeMessagingHosts\` + Name,
 	}
 )
 


### PR DESCRIPTION
### Summary
This pull request implements a fix for the issue with gopass-jsonapi configuration for Brave on Windows.
### Changes
- Updated the registry path for Brave integration.
- Verified that the configuration works as expected.
### Related Issue
Fixes #131