### PR TITLE
chore: migrate from urfave/cli v2 to v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/gopasspw/gopass v1.16.1
 	github.com/pquerna/otp v1.5.0
 	github.com/stretchr/testify v1.11.1
-	github.com/urfave/cli/v2 v2.27.7
+	github.com/urfave/cli/v3 v3.9.0
 	golang.org/x/exp v0.0.0-20251209150349-8475f28825e9
 	golang.org/x/net v0.48.0
 	golang.org/x/sys v0.39.0
@@ -48,6 +48,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/twpayne/go-pinentry/v4 v4.0.0 // indirect
+	github.com/urfave/cli/v2 v2.27.7 // indirect
 	github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342 // indirect
 	github.com/zalando/go-keyring v0.2.6 // indirect
 	golang.org/x/crypto v0.46.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -104,6 +104,8 @@ github.com/twpayne/go-pinentry/v4 v4.0.0 h1:8WcNa+UDVRzz7y9OEEU/nRMX+UGFPCAvl5Xs
 github.com/twpayne/go-pinentry/v4 v4.0.0/go.mod h1:aXvy+awVXqdH+GS0ddQ7AKHZ3tXM6fJ2NK+e16p47PI=
 github.com/urfave/cli/v2 v2.27.7 h1:bH59vdhbjLv3LAvIu6gd0usJHgoTTPhCFib8qqOwXYU=
 github.com/urfave/cli/v2 v2.27.7/go.mod h1:CyNAG/xg+iAOg0N4MPGZqVmv2rCoP267496AOXUZjA4=
+github.com/urfave/cli/v3 v3.9.0 h1:AV9lIiPv3ukYnxunaCUsHnEozptYmDN2F0+yWqLMn/c=
+github.com/urfave/cli/v3 v3.9.0/go.mod h1:ysVLtOEmg2tOy6PknnYVhDoouyC/6N42TMeoMzskhso=
 github.com/xrash/smetrics v0.0.0-20170218160415-a3153f7040e9/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
 github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342 h1:FnBeRrxr7OU4VvAzt5X7s6266i6cSVkkFPS0TuXWbIg=
 github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=

--- a/jsonapi.go
+++ b/jsonapi.go
@@ -1,14 +1,14 @@
 package main
 
 import (
+	"context"
 	"os"
 	"strings"
 
 	"github.com/blang/semver"
 	"github.com/gopasspw/gopass-jsonapi/internal/jsonapi"
-	"github.com/gopasspw/gopass/pkg/ctxutil"
 	"github.com/gopasspw/gopass/pkg/gopass"
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v3"
 )
 
 var (
@@ -21,10 +21,8 @@ type jsonapiCLI struct {
 }
 
 // listen reads a json message on stdin and responds on stdout.
-func (s *jsonapiCLI) listen(c *cli.Context) error {
-	ctx := ctxutil.WithGlobalFlags(c)
-
-	version, err := semver.Parse(strings.TrimPrefix(c.App.Version, "v"))
+func (s *jsonapiCLI) listen(ctx context.Context, c *cli.Command) error {
+	version, err := semver.Parse(strings.TrimPrefix(c.Root().Version, "v"))
 	if err != nil {
 		version = semver.Version{}
 	}

--- a/jsonapi_test.go
+++ b/jsonapi_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 
 	"github.com/gopasspw/gopass/pkg/ctxutil"
-	"github.com/gopasspw/gopass/tests/gptest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v3"
 )
 
 func TestJSONAPI(t *testing.T) {
@@ -18,9 +18,9 @@ func TestJSONAPI(t *testing.T) {
 
 	act := &jsonapiCLI{}
 
-	require.NoError(t, act.listen(gptest.CliCtx(ctx, t)))
+	require.NoError(t, act.listen(ctx, &cli.Command{}))
 
-	b, err := act.getBrowser(ctx, gptest.CliCtx(ctx, t))
+	b, err := act.getBrowser(ctx, &cli.Command{})
 	require.NoError(t, err)
 	assert.Equal(t, "chrome", b)
 }

--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/gopasspw/gopass/pkg/gopass/api"
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v3"
 )
 
 const (
@@ -48,14 +48,14 @@ func main() {
 		gp: gp,
 	}
 
-	app := cli.NewApp()
+	app := &cli.Command{}
 	app.Name = name
 	app.Version = getVersion().String()
 	app.Usage = "Setup and run gopass-jsonapi as native messaging hosts, e.g. for browser plugins"
-	app.EnableBashCompletion = true
-	app.Action = func(c *cli.Context) error {
+	app.EnableShellCompletion = true
+	app.Action = func(ctx context.Context, c *cli.Command) error {
 		if strings.HasSuffix(os.Args[0], "native_host") || strings.HasSuffix(os.Args[0], "native_host.exe") {
-			return ja.listen(c)
+			return ja.listen(ctx, c)
 		}
 
 		return cli.ShowAppHelp(c)
@@ -67,16 +67,16 @@ func main() {
 			Usage:       "Listen and respond to messages via stdin/stdout",
 			Description: "Gopass-jsonapi is started in listen mode from browser plugins using a wrapper specified in native messaging host manifests",
 			Hidden:      true,
-			Action: func(c *cli.Context) error {
-				return ja.listen(c)
+			Action: func(ctx context.Context, c *cli.Command) error {
+				return ja.listen(ctx, c)
 			},
 		},
 		{
 			Name:        "configure",
 			Usage:       "Setup gopass-jsonapi native messaging manifest for selected browser",
 			Description: "To access gopass from browser plugins, a native app manifest must be installed at the correct location",
-			Action: func(c *cli.Context) error {
-				return ja.setup(c)
+			Action: func(ctx context.Context, c *cli.Command) error {
+				return ja.setup(ctx, c)
 			},
 			Flags: []cli.Flag{
 				&cli.StringFlag{
@@ -112,7 +112,7 @@ func main() {
 		},
 		{
 			Name: "version",
-			Action: func(c *cli.Context) error {
+			Action: func(ctx context.Context, c *cli.Command) error {
 				cli.VersionPrinter(c)
 
 				return nil
@@ -120,7 +120,7 @@ func main() {
 		},
 	}
 
-	if err := app.RunContext(ctx, os.Args); err != nil {
+	if err := app.Run(ctx, os.Args); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/setup.go
+++ b/setup.go
@@ -9,10 +9,10 @@ import (
 	"github.com/fatih/color"
 	"github.com/gopasspw/gopass-jsonapi/internal/jsonapi/manifest"
 	"github.com/gopasspw/gopass/pkg/termio"
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v3"
 )
 
-func (s *jsonapiCLI) getBrowser(ctx context.Context, c *cli.Context) (string, error) {
+func (s *jsonapiCLI) getBrowser(ctx context.Context, c *cli.Command) (string, error) {
 	browser := c.String("browser")
 	if browser != "" {
 		return browser, nil
@@ -29,7 +29,7 @@ func (s *jsonapiCLI) getBrowser(ctx context.Context, c *cli.Context) (string, er
 	return browser, nil
 }
 
-func (s *jsonapiCLI) getGlobalInstall(ctx context.Context, c *cli.Context) (bool, error) {
+func (s *jsonapiCLI) getGlobalInstall(ctx context.Context, c *cli.Command) (bool, error) {
 	if !c.IsSet("global") {
 		return termio.AskForBool(ctx, color.BlueString("Install for all users? (might require sudo gopass)"), false)
 	}
@@ -37,7 +37,7 @@ func (s *jsonapiCLI) getGlobalInstall(ctx context.Context, c *cli.Context) (bool
 	return c.Bool("global"), nil
 }
 
-func (s *jsonapiCLI) getLibPath(ctx context.Context, c *cli.Context, browser string, global bool) (string, error) {
+func (s *jsonapiCLI) getLibPath(ctx context.Context, c *cli.Command, browser string, global bool) (string, error) {
 	if !c.IsSet("libpath") && runtime.GOOS == "linux" && (browser == "firefox" || browser == "floorp") && global {
 		return termio.AskForString(ctx, color.BlueString("What is your lib path?"), "/usr/lib")
 	}
@@ -45,7 +45,7 @@ func (s *jsonapiCLI) getLibPath(ctx context.Context, c *cli.Context, browser str
 	return c.String("libpath"), nil
 }
 
-func (s *jsonapiCLI) getWrapperPath(ctx context.Context, c *cli.Context, defaultWrapperPath string, wrapperName string) (string, error) {
+func (s *jsonapiCLI) getWrapperPath(ctx context.Context, c *cli.Command, defaultWrapperPath string, wrapperName string) (string, error) {
 	if path := c.String("path"); path != "" {
 		return path, nil
 	}

--- a/setup_others.go
+++ b/setup_others.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -11,15 +12,13 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/gopasspw/gopass-jsonapi/internal/jsonapi/manifest"
-	"github.com/gopasspw/gopass/pkg/ctxutil"
 	"github.com/gopasspw/gopass/pkg/gopass/api"
 	"github.com/gopasspw/gopass/pkg/termio"
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v3"
 )
 
 // setup sets up manifest for gopass as native messaging host.
-func (s *jsonapiCLI) setup(c *cli.Context) error {
-	ctx := ctxutil.WithGlobalFlags(c)
+func (s *jsonapiCLI) setup(ctx context.Context, c *cli.Command) error {
 	browser, err := s.getBrowser(ctx, c)
 	if err != nil {
 		return fmt.Errorf("failed to get browser: %w", err)

--- a/setup_windows.go
+++ b/setup_windows.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -12,15 +13,13 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/gopasspw/gopass-jsonapi/internal/jsonapi/manifest"
-	"github.com/gopasspw/gopass/pkg/ctxutil"
 	"github.com/gopasspw/gopass/pkg/termio"
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v3"
 	"golang.org/x/sys/windows/registry"
 )
 
 // setup sets up manifest for gopass as native messaging host.
-func (s *jsonapiCLI) setup(c *cli.Context) error {
-	ctx := ctxutil.WithGlobalFlags(c)
+func (s *jsonapiCLI) setup(ctx context.Context, c *cli.Command) error {
 	browser, err := s.getBrowser(ctx, c)
 	if err != nil {
 		return fmt.Errorf("failed to get browser: %s", err)


### PR DESCRIPTION
- Replace cli.NewApp() with &cli.Command{}
- Update EnableBashCompletion to EnableShellCompletion
- Replace app.RunContext with app.Run
- Update all action/handler signatures to (context.Context, *cli.Command) error
- Replace *cli.Context with *cli.Command throughout
- Replace c.App.Version with c.Root().Version
- Remove ctxutil.WithGlobalFlags calls; pass context directly
- Update tests to use &cli.Command{} instead of gptest.CliCtx
- Update go.mod to require github.com/urfave/cli/v3 v3.9.0